### PR TITLE
feat: counters per status and fixed get all address

### DIFF
--- a/src/AccountsTable.tsx
+++ b/src/AccountsTable.tsx
@@ -40,7 +40,7 @@ export default function AccountsTable() {
       setLoadingMultipleAddresses(false);
       setErrorMultipleAddresses(true);
       setErrorMessage(e.message);
-      console.error("Error getting addresses: " + e);
+      console.error("Error getting latest addresses: " + e);
     }
   }
 
@@ -54,7 +54,7 @@ export default function AccountsTable() {
       setLoadingMultipleAddresses(false);
       setErrorMultipleAddresses(true);
       setErrorMessage(e.message);
-      console.error("Error getting addresses: " + e);
+      console.error("Error getting historical addresses: " + e);
     }
   }
 

--- a/src/smartContract/types.ts
+++ b/src/smartContract/types.ts
@@ -9,4 +9,4 @@ export interface AddressIncentiveProgram {
   timestamp?: string;
 }
 
-export type AddressStatus = "claimed" | "pending" | "expired" | "renewed" | "notWhitelisted" | "unknown";
+export type AddressStatus = "claimed" | "pending" | "expired" | "renewed" | "notWhitelisted" | "unknown" | "error" ;


### PR DESCRIPTION
This is an initial fix to the "Get historical addresses" button. Current implementation is sequentially getting status per address which is is slow and inefficient while we find the time to optimize the queries. 
Currently UI was not modified, so counters are hidden on Browser Console instead of displayed on UI. This will be refactored in the future to have a UI section to display counters information.
Current status list:
* pending
* expired
* claimed
* notWhitelisted
* error
* rpc_error (when rpc errors fetching the data from contract)